### PR TITLE
Fix image size parsing for xz method

### DIFF
--- a/pisafe
+++ b/pisafe
@@ -923,7 +923,7 @@ file_image_size() {
     case $(file_ext "$INFILE") in
         img | iso)      SIZE_BYTES=$(echo $((  $(ls -s "$INFILE" | cut -d' ' -f1 ) * 1024 )) ) ;;
         zip)            SIZE_BYTES=$(zipinfo -t "$INFILE" 2> /dev/null | grep "%" | cut -d, -f2 | cut -d" " -f2  )  ;;
-        xz)             SIZE_BYTES=$(xz -l -v "$INFILE" 2> /dev/null | grep Uncompressed | sed 's/\s\s*/ /g' | cut -d'(' -f 2 | cut -d ' ' -f1 | sed 's/,//g')  ;;  
+        xz)             SIZE_BYTES=$(xz -l -v "$INFILE" 2> /dev/null | grep Uncompressed | sed 's/\s\s*/ /g' | cut -d'(' -f 2 | cut -d ' ' -f1 | sed 's/[^0-9]//g')  ;;  
         gz)             SIZE_BYTES=$(pigz -l "$INFILE" 2> /dev/null | grep -v compressed | sed 's/\s\s*/ /g' | sed -e 's/^[ \t]*//' | cut -d' ' -f 2 | sed 's/?/0/g')  ;;
      #  gz)             SIZE_BYTES=$(pigz -l "$INFILE" 2> /dev/null | grep -v compressed | sed 's/\s\s*/ /g' | sed -e 's/^[ \t]*//' | cut -d' ' -f 2 )  ;;
         zst)            SIZE_BYTES=$(zstd -v -l "$INFILE" 2> /dev/null | grep Decompressed | cut -d"(" -f2 | cut -d" " -f1) ;;


### PR DESCRIPTION
Hi,

I found an issue in the script related to the xz method. The output contained special characters, which caused the image size to display incorrectly. As a result, the RESTORE function would exit without writing to disk.

I modified the script so that only numeric characters are kept when parsing the size. This ensures both the RESTORE function and the image size display function work correctly.

I apologize for the confusion and for reopening the Pull Request, as I am still a beginner.

Thanks for the great script.

Regards
HovnovoD